### PR TITLE
Fix typo in -custom-prepare-exec prepare.sh runner setup

### DIFF
--- a/gitlab-runner/src/gitlab_runner.py
+++ b/gitlab-runner/src/gitlab_runner.py
@@ -211,7 +211,7 @@ def register_lxd(charm, https_proxy=None, http_proxy=None) -> bool:
            "--builds-dir", "/builds ",
            "--cache-dir", "/cache",
            "--custom-run-exec", "/opt/lxd-executor/run.sh",
-           "--custom-prepare-exec", "/opt/lxd-executor/prepare.sh ",
+           "--custom-prepare-exec", "/opt/lxd-executor/prepare.sh",
            "--custom-cleanup-exec", "/opt/lxd-executor/cleanup.sh",
            f"{proxyenv}"]
 


### PR DESCRIPTION
When setting up an LXD runner the template as an extra space that causes the runner to fail as follows: 
```
ERROR: Preparation failed: failed to start command: fork/exec /opt/lxd-executor/prepare.sh : no such file or directory
```

This PR addresses this by removing the extra space.