### PR TITLE
remove whitespace from builds directory path

### DIFF
--- a/gitlab-runner/src/gitlab_runner.py
+++ b/gitlab-runner/src/gitlab_runner.py
@@ -211,7 +211,7 @@ def register_lxd(charm, https_proxy=None, http_proxy=None) -> bool:
            f"--run-untagged={run_untagged}",
            f"--locked={locked}",
            "--executor", "custom",
-           "--builds-dir", "/builds ",
+           "--builds-dir", "/builds",
            "--cache-dir", "/cache",
            "--custom-run-exec", "/opt/lxd-executor/run.sh",
            "--custom-prepare-exec", "/opt/lxd-executor/prepare.sh",


### PR DESCRIPTION
Removing whitespace from /builds directory when registering LXD. This was causing issues when triggering a job via a webhook, e.g. export TRIGGER_PAYLOAD="/builds /repository.tmp/TRIGGER_PAYLOAD". This change fixes it.